### PR TITLE
fix: modifying the way data directories are handled.

### DIFF
--- a/configs/erigon_archive.json
+++ b/configs/erigon_archive.json
@@ -5,5 +5,5 @@
   "dockerhub_tag": "v2022.08.01",
   "dockerhub_repo": "thorax/erigon",
   "docker_port_mappings": "-p 8545:8545 -p 30303:30303 -p 8546:8546",
-  "docker_cmd": "erigon --chain=mainnet --http --http.vhosts=* --http.addr=0.0.0.0 --http.api=eth,debug,net,trace,web3,erigon,engine --torrent.upload.rate=1kb --metrics --metrics.addr=0.0.0.0"
+  "docker_cmd": "erigon --datadir /erigon_archive/data --chain=mainnet --http --http.vhosts=* --http.addr=0.0.0.0 --http.api=eth,debug,net,trace,web3,erigon,engine --torrent.upload.rate=1kb --metrics --metrics.addr=0.0.0.0"
 }

--- a/configs/geth_full.json
+++ b/configs/geth_full.json
@@ -5,5 +5,5 @@
   "dockerhub_tag": "v1.10.20",
   "dockerhub_repo": "ethereum/client-go",
   "docker_port_mappings": "-p 8545:8545 -p 30303:30303",
-  "docker_cmd": " --mainnet --syncmode full --txlookuplimit 0 --http --http.addr 0.0.0.0 --ws --graphql --metrics --metrics.addr 0.0.0.0"
+  "docker_cmd": " --datadir /geth_full/data --mainnet --syncmode full --txlookuplimit 0 --http --http.addr 0.0.0.0 --ws --graphql --metrics --metrics.addr 0.0.0.0"
 }

--- a/launcher.sh
+++ b/launcher.sh
@@ -73,6 +73,6 @@ cd $datadir
 # snapshot.
 latest=$(aws s3 ls "s3://${snapshots_bucket}/${chain}/${client}/${dockerhub_tag}/" | awk '{print $4}' | tail -1)
 aws s3 cp "s3://${snapshots_bucket}/${chain}/${client}/${dockerhub_tag}/${latest}" - | pv | /zstd/zstd --long=31 -d | tar -xf -
-docker run -d --name $client -v /$client/:/$client $docker_port_mappings ${dockerhub_repo}:${dockerhub_tag} $docker_cmd --datadir $datadir
+docker run -d --name $client -v ${datadir}:/${client}/data $docker_port_mappings ${dockerhub_repo}:${dockerhub_tag} $docker_cmd
 elapsed=$(( $(date +%s) - start_time ))
 echo "Downloaded snapshot and launched docker container in $elapsed seconds."


### PR DESCRIPTION
The user can still specify an arbitrary directory location, but when it
gets mounted in the docker container it is always at a fixed location:
`/$client_name/data/`, e.g. `/geth_full/data/`. This allows the configs
to essentially hardcode the datadir location.