### PR TITLE
fix: fix --request-payer to s3 commands

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -71,8 +71,8 @@ cd $datadir
 # The snapshots are named in a standard format with a timestamp in the name. This means that the lexicographical order
 # of the snapshots is also the creation order. Selecting the last snapshot listed means selecting the most recent
 # snapshot.
-latest=$(aws s3 ls "s3://${snapshots_bucket}/${chain}/${client}/${dockerhub_tag}/" --request-payer | awk '{print $4}' | tail -1)
-aws s3 cp "s3://${snapshots_bucket}/${chain}/${client}/${dockerhub_tag}/${latest}" - | pv | /zstd/zstd --long=31 -d | tar -xf -
+latest=$(aws s3 ls --request-payer requester "s3://${snapshots_bucket}/${chain}/${client}/${dockerhub_tag}/" | awk '{print $4}' | tail -1)
+aws s3 cp --request-payer requester "s3://${snapshots_bucket}/${chain}/${client}/${dockerhub_tag}/${latest}" - | pv | /zstd/zstd --long=31 -d | tar -xf -
 docker run -d --name $client -v ${datadir}:/${client}/data $docker_port_mappings ${dockerhub_repo}:${dockerhub_tag} $docker_cmd
 elapsed=$(( $(date +%s) - start_time ))
 echo "Downloaded snapshot and launched docker container in $elapsed seconds."


### PR DESCRIPTION
* Need --request-payer on both `s3 ls` and `s3 cp`
* Supply `requestor` argument to both of them